### PR TITLE
Save result of each trial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *$py.class
 
 **/*.Results/
+*.pdt
 
 db.sqlite3
 *.db

--- a/pyfemtet/opt/_femopt_core.py
+++ b/pyfemtet/opt/_femopt_core.py
@@ -532,7 +532,17 @@ class History:
 
         return columns, metadata
 
-    def record(self, parameters, objectives, constraints, obj_values, cns_values, message):
+    def record(
+            self,
+            parameters,
+            objectives,
+            constraints,
+            obj_values,
+            cns_values,
+            message,
+            file_content,  # with open(..., 'rb') as f: content = f.read()
+            file_path_creator,  # fem specific
+    ):
         """Records the optimization results in the history.
 
         Record only. NOT save.
@@ -590,6 +600,13 @@ class History:
             self._calc_non_domi(objectives)  # update self.local_data
             self._calc_hypervolume(objectives)  # update self.local_data
             self.actor_data = self.local_data
+
+            # save file
+            file_path = file_path_creator(self.local_data['trial'].values[-1])  # trial number is used to create filename
+            if file_path is not None:
+                # FIXME: run_on_schedular したい
+                with open(file_path, 'wb') as f:
+                    f.write(file_content)
 
     def _calc_non_domi(self, objectives):
 

--- a/pyfemtet/opt/_femopt_core.py
+++ b/pyfemtet/opt/_femopt_core.py
@@ -554,6 +554,8 @@ class History:
             obj_values (list): The objective values.
             cns_values (list): The constraint values.
             message (str): Additional information or messages related to the optimization results.
+            file_content (Bytes): Result file content(like .pdt of Femtet)
+            file_path_creator (Callable): A function who gets a trial(int) and returns a path to save file_content on scheduler.
 
         """
 

--- a/pyfemtet/opt/interface/_base.py
+++ b/pyfemtet/opt/interface/_base.py
@@ -63,12 +63,12 @@ class FEMInterface(ABC):
         """Preprocessing after launching a dask worker and before run optimization (if implemented in concrete class)."""
         pass
 
-    def create_result_file_content(self):
+    def create_result_file_content(self) -> 'Bytes' or None:
         """Called after solve"""
         pass
 
-    def create_file_path_creator(self, trial: int):
-        return _return_nothing
+    def create_file_path_on_scheduler(self, trial: int) -> str or None:
+        pass
 
 
 class NoFEM(FEMInterface):
@@ -76,7 +76,3 @@ class NoFEM(FEMInterface):
 
     def update(self, parameters: pd.DataFrame) -> None:
         pass
-
-
-def _return_nothing():
-    pass

--- a/pyfemtet/opt/interface/_base.py
+++ b/pyfemtet/opt/interface/_base.py
@@ -63,9 +63,20 @@ class FEMInterface(ABC):
         """Preprocessing after launching a dask worker and before run optimization (if implemented in concrete class)."""
         pass
 
+    def create_result_file_content(self):
+        """Called after solve"""
+        pass
+
+    def create_file_path_creator(self, trial: int):
+        return _return_nothing
+
 
 class NoFEM(FEMInterface):
     """Interface with no FEM for debug."""
 
     def update(self, parameters: pd.DataFrame) -> None:
         pass
+
+
+def _return_nothing():
+    pass

--- a/pyfemtet/opt/interface/_femtet.py
+++ b/pyfemtet/opt/interface/_femtet.py
@@ -668,3 +668,49 @@ class FemtetInterface(FEMInterface):
         result_dir = self.original_femprj_path.replace('.femprj', '.Results')
         pdt_path = os.path.join(result_dir, self.model_name + f'_trial{trial}.pdt')
         return pdt_path
+
+
+from win32com.client import Dispatch, constants
+
+class _UnPicklableNoFEM(FemtetInterface):
+
+
+    original_femprj_path = 'dummy'
+    model_name = 'dummy'
+    parametric_output_indexes_use_as_objective = None
+    kwargs = dict()
+    Femtet = None
+    quit_when_destruct = False
+
+    def __init__(self):
+        CoInitialize()
+        self.unpicklable_member = Dispatch('FemtetMacro.Femtet')
+        self.cns = constants
+
+    def _setup_before_parallel(self, *args, **kwargs):
+        pass
+
+    def check_param_value(self, *args, **kwargs):
+        pass
+
+    def update_parameter(self, *args, **kwargs):
+        pass
+
+    def update(self, *args, **kwargs):
+        pass
+
+    def create_result_file_content(self):
+        """Called after solve"""
+
+        # save to worker space
+        with open(__file__, 'rb') as f:
+            content = f.read()
+
+        return content
+
+    def create_file_path(self, trial: int):
+        # return path of scheduler environment
+        here = os.path.dirname(__file__)
+        pdt_path = os.path.join(here, f'trial{trial}.pdt')
+        return pdt_path
+

--- a/pyfemtet/opt/interface/_femtet.py
+++ b/pyfemtet/opt/interface/_femtet.py
@@ -646,3 +646,25 @@ class FemtetInterface(FEMInterface):
 
     def _version(self):
         return _version(Femtet=self.Femtet)
+
+    def create_result_file_content(self):
+        """Called after solve"""
+
+        # save to worker space
+        result_dir = self.femprj_path.replace('.femprj', '.Results')
+        pdt_path = os.path.join(result_dir, self.model_name + '.pdt')
+        succeed = self.Femtet.SavePDT(pdt_path, True)
+
+        if succeed:
+            with open(pdt_path, 'rb') as f:
+                content = f.read()
+            return content
+
+        else:
+            raise Exception('pdt ファイルの保存でエラーが発生しました。')
+
+    def create_file_path(self, trial: int):
+        # return path of scheduler environment
+        result_dir = self.original_femprj_path.replace('.femprj', '.Results')
+        pdt_path = os.path.join(result_dir, self.model_name + f'_trial{trial}.pdt')
+        return pdt_path

--- a/pyfemtet/opt/interface/_femtet.py
+++ b/pyfemtet/opt/interface/_femtet.py
@@ -106,6 +106,15 @@ class FemtetInterface(FEMInterface):
         # 開かれたモデルに応じて femprj_path と model を更新する
         self._connect_and_open_femtet()
 
+        # original_fem_prj が None なら必ず
+        # dask worker でないプロセスがオリジナルファイルを開いている
+        if self.original_femprj_path is None:
+            # dask worker でなければ original のはず
+            try:
+                worker = get_worker()
+            except ValueError:
+                self.original_femprj_path = self.femprj_path
+
         # 接続した Femtet の種類に応じて del 時に quit するかどうか決める
         self.quit_when_destruct = self.connected_method == 'new'
 

--- a/pyfemtet/opt/interface/_femtet.py
+++ b/pyfemtet/opt/interface/_femtet.py
@@ -59,9 +59,10 @@ class FemtetInterface(FEMInterface):
             self,
             femprj_path=None,
             model_name=None,
-            connect_method='auto',
-            strictly_pid_specify=True,
-            allow_without_project=False,
+            connect_method='auto',  # dask worker では __init__ の中で 'new' にするので super() の引数にしない。（しても意味がない）
+            save_pdt=False,
+            strictly_pid_specify=True,  # dask worker では True にしたいので super() の引数にしない。
+            allow_without_project=False,  # main でのみ True を許容したいので super() の引数にしない。
             open_result_with_gui=True,
             parametric_output_indexes_use_as_objective=None,
             **kwargs  # 継承されたクラスからの引数
@@ -80,6 +81,7 @@ class FemtetInterface(FEMInterface):
         self.allow_without_project = allow_without_project
         self.original_femprj_path = self.femprj_path
         self.open_result_with_gui = open_result_with_gui
+        self.save_pdt = save_pdt
 
         # その他のメンバーの宣言や初期化
         self.Femtet = None
@@ -126,6 +128,7 @@ class FemtetInterface(FEMInterface):
             model_name=self.model_name,
             open_result_with_gui=self.open_result_with_gui,
             parametric_output_indexes_use_as_objective=self.parametric_output_indexes_use_as_objective,
+            save_pdt=self.save_pdt
             **kwargs
         )
 
@@ -649,25 +652,32 @@ class FemtetInterface(FEMInterface):
 
     def create_result_file_content(self):
         """Called after solve"""
+        if self.save_pdt:
+            # save to worker space
+            result_dir = self.femprj_path.replace('.femprj', '.Results')
+            pdt_path = os.path.join(result_dir, self.model_name + '.pdt')
+            succeed = self.Femtet.SavePDT(pdt_path, True)
 
-        # save to worker space
-        result_dir = self.femprj_path.replace('.femprj', '.Results')
-        pdt_path = os.path.join(result_dir, self.model_name + '.pdt')
-        succeed = self.Femtet.SavePDT(pdt_path, True)
+            # convert .pdt to ByteIO
+            if succeed:
+                with open(pdt_path, 'rb') as f:
+                    content = f.read()
+                return content
 
-        if succeed:
-            with open(pdt_path, 'rb') as f:
-                content = f.read()
-            return content
+            else:
+                raise Exception('pdt ファイルの保存でエラーが発生しました。')
 
         else:
-            raise Exception('pdt ファイルの保存でエラーが発生しました。')
+            return super().create_result_file_content()  # do nothing
 
-    def create_file_path(self, trial: int):
-        # return path of scheduler environment
-        result_dir = self.original_femprj_path.replace('.femprj', '.Results')
-        pdt_path = os.path.join(result_dir, self.model_name + f'_trial{trial}.pdt')
-        return pdt_path
+    def create_file_path_on_scheduler(self, trial: int):
+        if self.save_pdt:
+            # return path of scheduler environment
+            result_dir = self.original_femprj_path.replace('.femprj', '.Results')
+            pdt_path = os.path.join(result_dir, self.model_name + f'_trial{trial}.pdt')
+            return pdt_path
+        else:
+            return super().create_file_path_on_scheduler(trial)  # do nothing
 
 
 from win32com.client import Dispatch, constants

--- a/pyfemtet/opt/interface/_femtet.py
+++ b/pyfemtet/opt/interface/_femtet.py
@@ -128,7 +128,7 @@ class FemtetInterface(FEMInterface):
             model_name=self.model_name,
             open_result_with_gui=self.open_result_with_gui,
             parametric_output_indexes_use_as_objective=self.parametric_output_indexes_use_as_objective,
-            save_pdt=self.save_pdt
+            save_pdt=self.save_pdt,
             **kwargs
         )
 

--- a/pyfemtet/opt/opt/_base.py
+++ b/pyfemtet/opt/opt/_base.py
@@ -89,7 +89,7 @@ class AbstractOptimizer(ABC):
             c,
             self.message,
             file_content=self.fem.create_result_file_content(),  # with open(..., 'rb') as f: content = f.read()
-            file_path_creator=self.fem.create_file_path,  # fem specific
+            file_path_creator=self.fem.create_file_path_on_scheduler,  # fem specific
         )
 
         logger.debug('history.record end')

--- a/pyfemtet/opt/opt/_base.py
+++ b/pyfemtet/opt/opt/_base.py
@@ -88,6 +88,8 @@ class AbstractOptimizer(ABC):
             y,
             c,
             self.message,
+            file_content=self.fem.create_result_file_content(),  # with open(..., 'rb') as f: content = f.read()
+            file_path_creator=self.fem.create_file_path,  # fem specific
         )
 
         logger.debug('history.record end')

--- a/tests/test_10_SavePDT/test_unpicklable.py
+++ b/tests/test_10_SavePDT/test_unpicklable.py
@@ -54,6 +54,6 @@ if __name__ == '__main__':
     # femopt.add_objective(coordinate, 'y', args=(femopt.opt, 1))
     # femopt.add_objective(coordinate, 'z', args=(femopt.opt, 2))
 
-    femopt.optimize(n_parallel=3)
+    femopt.optimize(n_parallel=3, n_trials=60)
     femopt.terminate_all()
 

--- a/tests/test_10_SavePDT/test_unpicklable.py
+++ b/tests/test_10_SavePDT/test_unpicklable.py
@@ -1,0 +1,59 @@
+from time import sleep
+
+from pyfemtet.opt.interface._femtet import _UnPicklableNoFEM
+
+import numpy as np
+
+from pyfemtet.opt import FEMOpt, NoFEM
+
+
+class SuperSphere:
+    def __init__(self, n):
+        self.n = n
+
+    def x(self, radius, *angles):
+        assert len(angles) == self.n - 1, 'invalid angles length'
+
+        out = []
+
+        for i in range(self.n):
+            if i == 0:
+                out.append(radius * np.cos(angles[0]))
+            elif i < self.n - 1:
+                product = radius
+                for j in range(i):
+                    product *= np.sin(angles[j])
+                product *= np.cos(angles[i])
+                out.append(product)
+            else:
+                product = radius
+                for j in range(i):
+                    product *= np.sin(angles[j])
+                out.append(product)
+        return out
+
+
+s = SuperSphere(3)
+
+
+def coordinate(_, opt, i):
+    sleep(1)
+    return s.x(*opt.get_parameter('values'))[i]
+
+
+if __name__ == '__main__':
+
+    fem = _UnPicklableNoFEM()
+    femopt = FEMOpt(fem=fem)
+
+    femopt.add_parameter('r', 0.5, 0, 1)
+    femopt.add_parameter('fai', np.pi/2, 0, np.pi)
+    femopt.add_parameter('theta', 0, 0, 2*np.pi)
+
+    femopt.add_objective(coordinate, 'x', args=(femopt.opt, 0))
+    # femopt.add_objective(coordinate, 'y', args=(femopt.opt, 1))
+    # femopt.add_objective(coordinate, 'z', args=(femopt.opt, 2))
+
+    femopt.optimize(n_parallel=3)
+    femopt.terminate_all()
+

--- a/tests/test_4_constants/test_simple_femtet_with_constants.py
+++ b/tests/test_4_constants/test_simple_femtet_with_constants.py
@@ -79,7 +79,25 @@ def test_simple_femtet_with_constants():
     femopt.terminate_all()
 
 
+def test_save_pdt():
+    # n_parallel が 1, 3, cluster の時にテストすること。
+    femprj_path = os.path.join(here, f'{me.replace(".py", ".femprj")}')
+
+    fem = FemtetInterface(femprj_path, connect_method='new', save_pdt=True)
+    femopt = FEMOpt(fem=fem, scheduler_address=None)
+    femopt.opt.seed = 42
+    femopt.add_parameter('d', 5, 1, 10)
+    femopt.add_parameter('h', 5, 1, 10)
+    femopt.add_parameter('w', 5, 1, 10)
+    femopt.add_objective(max_disp, '最大変位(m)')
+    femopt.add_objective(volume, '体積(mm3)', args=femopt.opt)
+    femopt.add_objective(mises, 'mises 応力()')
+    femopt.add_constraint(bottom_surface, '底面積<=30', upper_bound=30, args=femopt.opt)
+    femopt.optimize(n_trials=10, n_parallel=1, wait_setup=True)
+    femopt.terminate_all()
+
+
 if __name__ == '__main__':
-    test_simple_femtet_with_constants()
+    test_save_pdt()
 
 

--- a/tests/test_99_cluster/remote_cluster_test.py
+++ b/tests/test_99_cluster/remote_cluster_test.py
@@ -4,8 +4,9 @@ from time import sleep
 from subprocess import Popen
 
 import numpy as np
+from win32com.client import constants
 
-from pyfemtet.opt import FEMOpt, NoFEM
+from pyfemtet.opt import FEMOpt, NoFEM, FemtetInterface
 
 
 here, me = os.path.split(__file__)
@@ -73,5 +74,72 @@ def test_local_cluster():
     femopt.optimize(n_parallel=3, n_trials=30)
     femopt.terminate_all()
 
+
+def max_disp(Femtet):
+    return Femtet.Gogh.Galileo.GetMaxDisplacement_py()[1]
+
+
+def volume(Femtet, opt):
+    d, h, _ = opt.get_parameter('values')
+    w = Femtet.GetVariableValue('w')
+    return d * h * w
+
+
+def mises(Femtet):
+    Gogh = Femtet.Gogh
+    Gogh.Galileo.Tensor = constants.GALILEO_STRESS_C
+    _, tensor = Gogh.Galileo.GetTensorAtNode_py(Gogh.Data.MeshElementArray(0).MeshNodeArray(0).Index, 0)
+    _, value = Gogh.Galileo.TransEquivalentValue_py(constants.GALILEO_STRESS_C, tensor, 0)
+    return value
+
+
+def bottom_surface(_, opt):
+    d, h, w = opt.get_parameter('values')
+    return d * w
+
+
+def test_remote_cluster_with_femtet():
+    # get remote info
+    json_path = os.path.join(here, 'remote.json')
+    with open(json_path, 'r') as f:
+        json_data = json.load(f)
+    hostname = json_data['hostname']
+    port = json_data['port']
+
+    # launch scheduler
+    Popen(
+        f'powershell -file launch_scheduler.ps1 -port {port}',
+        shell=True
+    )
+    sleep(10)
+
+    # fem setup
+    femprj_path = os.path.join(
+        here,
+        '..',
+        'test_4_constants',
+        'test_simple_femtet_with_constants.femprj'
+    )
+    fem = FemtetInterface(
+        femprj_path, connect_method='new',
+        save_pdt = True
+    )
+
+    # femopt setup
+    femopt = FEMOpt(fem=fem, scheduler_address=f'tcp://{hostname}:{port}')
+
+    # problem setup
+    femopt.opt.seed = 42
+    femopt.add_parameter('d', 5, 1, 10)
+    femopt.add_parameter('h', 5, 1, 10)
+    femopt.add_parameter('w', 5, 1, 10)
+    femopt.add_objective(max_disp, '最大変位(m)')
+    femopt.add_objective(volume, '体積(mm3)', args=femopt.opt)
+    femopt.add_objective(mises, 'mises 応力()')
+    femopt.add_constraint(bottom_surface, '底面積<=30', upper_bound=30, args=femopt.opt)
+    femopt.optimize(n_trials=10, n_parallel=3, wait_setup=True)
+    femopt.terminate_all()
+
+
 if __name__ == '__main__':
-    test_local_cluster()
+    test_remote_cluster_with_femtet()


### PR DESCRIPTION
- Added save_pdt to the FemtetInterface arguments.
- Added file_content and file_path_creator to the Hisotory.record arguments.
  - file_path_creator generates a FEM-specific result file path from the trial number in the scheduler environment.
  - For future extensibility, implemented FEMInterface.create_file_content() and FEMInterface.create_file_path_on_scheduler() so that AbstractOptimizer.f() passes these to History.