### PR TITLE
Enhance nx update model

### DIFF
--- a/pyfemtet/opt/femprj_sample/cad_ex01_NX.py
+++ b/pyfemtet/opt/femprj_sample/cad_ex01_NX.py
@@ -107,6 +107,10 @@ if __name__ == '__main__':
     fem = FemtetWithNXInterface(
         prt_path='cad_ex01_NX.prt',
         open_result_with_gui=False,  # To calculate von Mises stress, set this argument to False. See Femtet Macro Help.
+        export_curves=False,
+        export_surfaces=False,
+        export_solids=True,
+        export_flattened_assembly=False,
     )
 
     # Initialize the FEMOpt object.

--- a/pyfemtet/opt/femprj_sample_jp/cad_ex01_NX_jp.py
+++ b/pyfemtet/opt/femprj_sample_jp/cad_ex01_NX_jp.py
@@ -103,6 +103,10 @@ if __name__ == '__main__':
     fem = FemtetWithNXInterface(
         prt_path='cad_ex01_NX.prt',
         open_result_with_gui=False,
+        export_curves=False,
+        export_surfaces=False,
+        export_solids=True,
+        export_flattened_assembly=False,
     )
 
     # FEMOpt オブジェクトの初期化 (最適化問題とFemtetとの接続を行います)

--- a/pyfemtet/opt/interface/_femtet_with_nx/_interface.py
+++ b/pyfemtet/opt/interface/_femtet_with_nx/_interface.py
@@ -102,10 +102,27 @@ class FemtetWithNXInterface(FemtetInterface):
             tmp_dict[row['name']] = row['value']
         str_json = json.dumps(tmp_dict)
 
+        # create dumped json of export settings
+        tmp_dict = dict(
+            include_curves=self.export_curves,
+            include_surfaces=self.export_surfaces,
+            include_solids=self.export_solids,
+            flatten_assembly=self.export_flattened_assembly,
+        )
+        dumped_json_export_settings = json.dumps(tmp_dict)
+
         # NX journal を使ってモデルを編集する
         env = os.environ.copy()
         subprocess.run(
-            [self.run_journal_path, self._JOURNAL_PATH, '-args', self.prt_path, str_json, x_t_path],
+            [
+                self.run_journal_path,  # run_journal.exe
+                self._JOURNAL_PATH,  # update_model.py
+                '-args',
+                self.prt_path,
+                str_json,
+                x_t_path,
+                dumped_json_export_settings,
+            ],
             env=env,
             shell=True,
             cwd=os.path.dirname(self.prt_path)

--- a/pyfemtet/opt/interface/_femtet_with_nx/_interface.py
+++ b/pyfemtet/opt/interface/_femtet_with_nx/_interface.py
@@ -54,8 +54,8 @@ class FemtetWithNXInterface(FemtetInterface):
 
         self.export_curves = export_curves
         self.export_surfaces = export_surfaces
-        self.export_solids = export_surfaces
-        self.export_flattened_assembly = export_surfaces
+        self.export_solids = export_solids
+        self.export_flattened_assembly = export_flattened_assembly
 
         # FemtetInterface の設定 (femprj_path, model_name の更新など)
         # + restore 情報の上書き
@@ -63,8 +63,8 @@ class FemtetWithNXInterface(FemtetInterface):
             prt_path=self.prt_path,
             export_curves=self.export_curves,
             export_surfaces=self.export_surfaces,
-            export_solids=self.export_surfaces,
-            export_flattened_assembly=self.export_surfaces,
+            export_solids=self.export_solids,
+            export_flattened_assembly=self.export_flattened_assembly,
             **kwargs
         )
 

--- a/pyfemtet/opt/interface/_femtet_with_nx/_interface.py
+++ b/pyfemtet/opt/interface/_femtet_with_nx/_interface.py
@@ -17,6 +17,10 @@ class FemtetWithNXInterface(FemtetInterface):
 
     Args:
         prt_path: The path to the prt file.
+        export_curves(bool or None): Parasolid export setting of NX. If None, PyFemtet does not change the setting of NX. Defaults to None.
+        export_surfaces(bool or None): Parasolid export setting of NX. If None, PyFemtet does not change the setting of NX. Defaults to None.
+        export_solids(bool or None): Parasolid export setting of NX. If None, PyFemtet does not change the setting of NX. Defaults to None.
+        export_flattened_assembly(bool or None): Parasolid export setting of NX. If None, PyFemtet does not change the setting of NX. Defaults to None.
 
     For details of The other arguments, see ``FemtetInterface``.
 
@@ -27,9 +31,12 @@ class FemtetWithNXInterface(FemtetInterface):
     def __init__(
             self,
             prt_path,
+            export_curves: bool or None = None,
+            export_surfaces: bool or None = None,
+            export_solids: bool or None = None,
+            export_flattened_assembly: bool or None = None,
             **kwargs
     ):
-
         # check NX installation
         self.run_journal_path = os.path.join(os.environ.get('UGII_BASE_DIR'), 'NXBIN', 'run_journal.exe')
         if not os.path.isfile(self.run_journal_path):
@@ -45,10 +52,19 @@ class FemtetWithNXInterface(FemtetInterface):
         except ValueError:  # get_worker に失敗した場合
             self.prt_path = os.path.abspath(prt_path)
 
+        self.export_curves = export_curves
+        self.export_surfaces = export_surfaces
+        self.export_solids = export_surfaces
+        self.export_flattened_assembly = export_surfaces
+
         # FemtetInterface の設定 (femprj_path, model_name の更新など)
         # + restore 情報の上書き
         super().__init__(
             prt_path=self.prt_path,
+            export_curves=self.export_curves,
+            export_surfaces=self.export_surfaces,
+            export_solids=self.export_surfaces,
+            export_flattened_assembly=self.export_surfaces,
             **kwargs
         )
 

--- a/pyfemtet/opt/interface/_femtet_with_nx/update_model.py
+++ b/pyfemtet/opt/interface/_femtet_with_nx/update_model.py
@@ -1,29 +1,24 @@
 import os
 import sys
 import json
+from xml.etree.ElementInclude import include
+
 import NXOpen
 
 
-def main(prtPath:str, parameters:'dict as str', x_tPath:str = None):
-    '''
-    .prt ファイルのパスを受け取り、parameters に指定された変数を更新し、
-    x_tPath が None のときは.prt と同じディレクトリに
-    .x_t ファイルをエクスポートする
+def main(
+        prtPath: str,
+        parameters: str,  # dumped json
+        x_tPath: str = None,
+        include_curves: bool or None = None,  # None: same with user's last export setting
+        include_surfaces: bool or None = None,  # None: same with user's last export setting
+        include_solids: bool or None = None,  # None: same with user's last export setting
+        flatten_assembly: bool or None = None,  # None: same with user's last export setting
+):
+    """Update the parameter of .prt file and export to .x_t file."""
 
-    Parameters
-    ----------
-    prtPath : str
-        DESCRIPTION.
-    parameters : 'dict as str'
-        DESCRIPTION.
-
-    Returns
-    -------
-    None.
-
-    '''    
     # 保存先の設定
-    prtPath = os.path.abspath(prtPath) # 一応
+    prtPath = os.path.abspath(prtPath)
     if x_tPath is None:
         x_tPath = os.path.splitext(prtPath)[0] + '.x_t'
 
@@ -40,7 +35,6 @@ def main(prtPath:str, parameters:'dict as str', x_tPath:str = None):
     displayPart = theSession.Parts.Display
 
     # 式を更新
-    unit_mm = workPart.UnitCollection.FindObject("MilliMeter")
     for k, v in parameters.items():
         try:
             exp = workPart.Expressions.FindObject(k)
@@ -48,14 +42,15 @@ def main(prtPath:str, parameters:'dict as str', x_tPath:str = None):
             print(f'├ 変数{k}は .prt ファイルに含まれていません。無視されます。')
             continue
 
-        workPart.Expressions.EditWithUnits(exp, unit_mm, str(v))
+        workPart.Expressions.Edit(exp, str(v))
         # 式の更新を適用
         id1 = theSession.NewestVisibleUndoMark
         try:
             nErrs1 = theSession.UpdateManager.DoUpdate(id1)
         # 更新に失敗
         except NXOpen.NXException as e:
-            print('└ 形状が破綻しました。操作を取り消します。')
+            print(f'├ ERROR! {e}')
+            print(f'└ 形状が破綻しました。操作を取り消します。')
             return None
 
     print('│ model 更新に成功しました。')
@@ -64,19 +59,28 @@ def main(prtPath:str, parameters:'dict as str', x_tPath:str = None):
         # parasolid のエクスポート
         parasolidExporter1 = theSession.DexManager.CreateParasolidExporter()
 
-        parasolidExporter1.ObjectTypes.Curves = False
-        parasolidExporter1.ObjectTypes.Surfaces = False
-        parasolidExporter1.ObjectTypes.Solids = True
+        if include_curves is not None:
+            parasolidExporter1.ObjectTypes.Curves = include_curves
+
+        if include_surfaces is not None:
+            parasolidExporter1.ObjectTypes.Surfaces = include_surfaces
+
+        if include_solids is not None:
+            parasolidExporter1.ObjectTypes.Solids = include_solids
+
+        if flatten_assembly is not None:
+            parasolidExporter1.FlattenAssembly = flatten_assembly
 
         parasolidExporter1.InputFile = prtPath
         parasolidExporter1.ParasolidVersion = NXOpen.ParasolidExporter.ParasolidVersionOption.Current
         parasolidExporter1.OutputFile = x_tPath
 
         parasolidExporter1.Commit()
-
         parasolidExporter1.Destroy()
-    except:
-        print('└ parasolid 更新に失敗しました。')
+
+    except Exception as e:
+        print(f'├ ERROR! {e}')
+        print(f'└ parasolid 更新に失敗しました。')
         return None
 
     print('└ parasolid 更新が正常に終了しました。')

--- a/pyfemtet/opt/interface/_femtet_with_nx/update_model.py
+++ b/pyfemtet/opt/interface/_femtet_with_nx/update_model.py
@@ -9,11 +9,8 @@ import NXOpen
 def main(
         prtPath: str,
         parameters: str,  # dumped json
-        x_tPath: str = None,
-        include_curves: bool or None = None,  # None: same with user's last export setting
-        include_surfaces: bool or None = None,  # None: same with user's last export setting
-        include_solids: bool or None = None,  # None: same with user's last export setting
-        flatten_assembly: bool or None = None,  # None: same with user's last export setting
+        x_tPath: str,
+        dumped_json_export_settings: str,
 ):
     """Update the parameter of .prt file and export to .x_t file."""
 
@@ -24,7 +21,14 @@ def main(
 
     # 辞書の作成
     parameters = json.loads(parameters)
-    
+
+    # export 設定
+    settings = json.loads(dumped_json_export_settings)
+    include_curves = settings['include_curves']
+    include_surfaces = settings['include_surfaces']
+    include_solids = settings['include_solids']
+    flatten_assembly = settings['flatten_assembly']
+
     # session の取得とパートを開く
     theSession = NXOpen.Session.GetSession()
     theSession.Parts.OpenActiveDisplay(prtPath, NXOpen.DisplayPartOption.AllowAdditional)


### PR DESCRIPTION
- Add dumped_json_export_settings argument to update_model. It is a dumped dict. The key of dict is following:
  - include_curves
  - include_surfaces
  - include_solids
  - flatten_assembly
- To set these values, now FemtetWithNXInterface has export_... arguments on its constructer.

By this, user can specify export settings of NX for reproductibity.
If no value is specified, the settings follow user's NX environment settings.